### PR TITLE
Fix drop firefox

### DIFF
--- a/internal/port/ui/assets/js/form-utils.js
+++ b/internal/port/ui/assets/js/form-utils.js
@@ -35,6 +35,11 @@ function isLikelyPEM(input) {
     return pemRegex.test(input);
 }
 
+// required to make drop work on Firefox
+pem.ondragover = function(e){
+    e.preventDefault();
+}
+
 pem.ondrop = function (e) {
     e.preventDefault();
     const file = e.dataTransfer.files[0];

--- a/internal/port/ui/assets/js/form-utils.js
+++ b/internal/port/ui/assets/js/form-utils.js
@@ -36,8 +36,20 @@ function isLikelyPEM(input) {
 }
 
 // required to make drop work on Firefox
-pem.ondragover = function(e){
+pem.ondragover = function(e) {
     e.preventDefault();
+
+    if (!e.target.classList.contains('drop-indicator')) {
+        e.target.classList.add('drop-indicator')
+    }
+}
+
+pem.ondragend = function (e) {
+    e.target.classList.remove('drop-indicator')
+}
+
+pem.ondragleave = function (e) {
+    e.target.classList.remove('drop-indicator')
 }
 
 pem.ondrop = function (e) {

--- a/internal/port/ui/assets/styling/styles.css
+++ b/internal/port/ui/assets/styling/styles.css
@@ -115,3 +115,7 @@ nav[role="tab-control"] label.active {
 .tree details[open] > summary::before {
     background-position: calc(-2 * var(--radius)) 0;
 }
+
+textarea.drop-indicator {
+    border: 2px dashed var(--pico-primary-hover);
+}

--- a/internal/port/ui/templates/pages/index.html
+++ b/internal/port/ui/templates/pages/index.html
@@ -40,6 +40,9 @@
                         rows="8"
                         aria-label="PEM"
                         aria-describedby="pem-helper"
+                        placeholder="-----BEGIN CERTIFICATE-----
+<content>
+-----END CERTIFICATE-----"
                 ></textarea>
                 <small id="pem-helper">Paste or drag & drop a PEM file here</small>
             </fieldset>

--- a/internal/port/ui/templates/pages/index.html
+++ b/internal/port/ui/templates/pages/index.html
@@ -40,8 +40,7 @@
                         rows="8"
                         aria-label="PEM"
                         aria-describedby="pem-helper"
-                >
-            </textarea>
+                ></textarea>
                 <small id="pem-helper">Paste or drag & drop a PEM file here</small>
             </fieldset>
             <button type="submit">


### PR DESCRIPTION
Drag & drop was not working in Firefox.

Also added some UI tweaks to improve the UX:
1. Add dropzone indicator (dotted lines)
2. Show placeholder content for the PEM textarea
3. Removed default whitespace from the textarea

See commit messages for full details.

**Screenshot**

<img width="1624" alt="Screenshot 2025-02-28 at 12 18 55" src="https://github.com/user-attachments/assets/6a436d29-d628-4744-bef7-bd6cfb0994eb" />
